### PR TITLE
More consistency and compat for Cavern & Chasms

### DIFF
--- a/config/jei/blacklist.cfg
+++ b/config/jei/blacklist.cfg
@@ -149,6 +149,7 @@ caverns_and_chasms:golden_bars
 caverns_and_chasms:golden_lantern
 caverns_and_chasms:gravestone
 caverns_and_chasms:mime_spawn_egg
+caverns_and_chasms:rocky_dirt
 caverns_and_chasms:rotten_egg
 caverns_and_chasms:zombie_chicken_spawn_egg
 charm:coral_squid_bucket

--- a/openloader/resources/crucial_resources/assets/quark/lang/en_us.json
+++ b/openloader/resources/crucial_resources/assets/quark/lang/en_us.json
@@ -1,0 +1,12 @@
+{
+	"block.quark.cobblestone_bricks": "Crude Cobblestone Bricks",
+	"block.quark.mossy_cobblestone_bricks": "Crude Mossy Cobblestone Bricks",
+	"block.quark.cobblestone_bricks_stairs": "Crude Cobblestone Brick Stairs",
+	"block.quark.mossy_cobblestone_bricks_stairs": "Crude Mossy Cobblestone Brick Stairs",
+	"block.quark.cobblestone_bricks_slab": "Crude Cobblestone Brick Slab",
+	"block.quark.mossy_cobblestone_bricks_slab": "Crude Mossy Cobblestone Brick Slab",
+	"block.quark.cobblestone_bricks_vertical_slab": "Crude Cobblestone Brick Vertical Slab",
+	"block.quark.mossy_cobblestone_bricks_vertical_slab": "Crude Mossy Cobblestone Brick Vertical Slab",
+	"block.quark.cobblestone_bricks_wall": "Crude Cobblestone Brick Wall",
+	"block.quark.mossy_cobblestone_bricks_wall": "Crude Mossy Cobblestone Brick Wall"
+}

--- a/openloader/resources/crucial_resources/assets/quark/lang/en_us.json
+++ b/openloader/resources/crucial_resources/assets/quark/lang/en_us.json
@@ -8,5 +8,11 @@
 	"block.quark.cobblestone_bricks_vertical_slab": "Crude Cobblestone Brick Vertical Slab",
 	"block.quark.mossy_cobblestone_bricks_vertical_slab": "Crude Mossy Cobblestone Brick Vertical Slab",
 	"block.quark.cobblestone_bricks_wall": "Crude Cobblestone Brick Wall",
-	"block.quark.mossy_cobblestone_bricks_wall": "Crude Mossy Cobblestone Brick Wall"
+	"block.quark.mossy_cobblestone_bricks_wall": "Crude Mossy Cobblestone Brick Wall",
+	
+	"block.quark.dirt_bricks": "Crude Dirt Bricks",
+	"block.quark.dirt_bricks_stairs": "Crude Dirt Brick Stairs",
+	"block.quark.dirt_bricks_slab": "Crude Dirt Brick Slab",
+	"block.quark.dirt_bricks_vertical_slab": "Crude Dirt Brick Vertical Slab",
+	"block.quark.dirt_bricks_wall": "Crude Dirt Brick Wall"
 }

--- a/scripts/caverns_n_chasms_compat.zs
+++ b/scripts/caverns_n_chasms_compat.zs
@@ -29,6 +29,7 @@ var quark_mossycobblebrick = <item:quark:mossy_cobblestone_bricks>;
 # Remove Overlapping Content
 craftingTable.removeRecipe(<item:caverns_and_chasms:golden_bars>);
 craftingTable.removeRecipe(<item:caverns_and_chasms:golden_lantern>);
+craftingTable.removeRecipe(<item:caverns_and_chasms:rocky_dirt>);
 
 # Edit Overlapping Content
 craftingTable.removeRecipe(cc_cobblebrick);
@@ -69,7 +70,6 @@ tag.add(<item:caverns_and_chasms:sugilite_lamp>);
 tag.add(<item:caverns_and_chasms:lapis_bricks>);
 tag.add(<item:caverns_and_chasms:lapis_pillar>);
 tag.add(<item:caverns_and_chasms:lapis_lamp>);
-tag.add(<item:caverns_and_chasms:rocky_dirt>);
 tag.add(<item:caverns_and_chasms:dirt_bricks>);
 tag.add(<item:caverns_and_chasms:dirt_tiles>);
 tag.add(<item:caverns_and_chasms:cobblestone_tiles>);

--- a/scripts/caverns_n_chasms_compat.zs
+++ b/scripts/caverns_n_chasms_compat.zs
@@ -11,6 +11,8 @@ println("Chaverns & Chasms detected. Loading C&C Compat!");
 // INTEGRATION ======================
 
 var blaze_powder = <item:minecraft:blaze_powder>;
+var cc_cobblebrick = <item:caverns_and_chasms:cobblestone_bricks>;
+var cc_mossycobblebrick = <item:caverns_and_chasms:mossy_cobblestone_bricks>;
 var chest = <tag:items:forge:chests/wooden>;
 var crate = <item:quark:crate>;
 var emerald = <item:minecraft:emerald>;
@@ -21,10 +23,24 @@ var planks = <tag:items:minecraft:planks>;
 var prismarine_crystals = <item:minecraft:prismarine_crystals>;
 var silver = <tag:items:forge:ingots/silver>;
 var sugilite = <item:caverns_and_chasms:sugilite>;
+var quark_cobblebrick = <item:quark:cobblestone_bricks>;
+var quark_mossycobblebrick = <item:quark:mossy_cobblestone_bricks>;
 
 # Remove Overlapping Content
 craftingTable.removeRecipe(<item:caverns_and_chasms:golden_bars>);
 craftingTable.removeRecipe(<item:caverns_and_chasms:golden_lantern>);
+
+# Edit Overlapping Content
+craftingTable.removeRecipe(cc_cobblebrick);
+craftingTable.addShaped("cc_cobblebrick_compat", 
+		cc_cobblebrick * 4,  
+		[[quark_cobblebrick, quark_cobblebrick],
+		 [quark_cobblebrick, quark_cobblebrick]]);
+craftingTable.removeByName("caverns_and_chasms:cobblestone/mossy_cobblestone_bricks/mossy_cobblestone_bricks");
+craftingTable.addShaped("cc_mossycobblebrick_compat", 
+		cc_mossycobblebrick * 4,  
+		[[quark_mossycobblebrick, quark_mossycobblebrick],
+		 [quark_mossycobblebrick, quark_mossycobblebrick]]);
 
 # Crate uses Silver
 craftingTable.removeRecipe(crate);

--- a/scripts/caverns_n_chasms_compat.zs
+++ b/scripts/caverns_n_chasms_compat.zs
@@ -12,9 +12,11 @@ println("Chaverns & Chasms detected. Loading C&C Compat!");
 
 var blaze_powder = <item:minecraft:blaze_powder>;
 var cc_cobblebrick = <item:caverns_and_chasms:cobblestone_bricks>;
+var cc_dirtbrick = <item:caverns_and_chasms:dirt_bricks>;
 var cc_mossycobblebrick = <item:caverns_and_chasms:mossy_cobblestone_bricks>;
 var chest = <tag:items:forge:chests/wooden>;
 var crate = <item:quark:crate>;
+var dirt = <item:minecraft:dirt>;
 var emerald = <item:minecraft:emerald>;
 var ender_eye = <item:minecraft:ender_eye>;
 var ender_pearl = <item:minecraft:ender_pearl>;
@@ -24,6 +26,7 @@ var prismarine_crystals = <item:minecraft:prismarine_crystals>;
 var silver = <tag:items:forge:ingots/silver>;
 var sugilite = <item:caverns_and_chasms:sugilite>;
 var quark_cobblebrick = <item:quark:cobblestone_bricks>;
+var quark_dirtbrick = <item:quark:dirt_bricks>;
 var quark_mossycobblebrick = <item:quark:mossy_cobblestone_bricks>;
 
 # Remove Overlapping Content
@@ -37,6 +40,16 @@ craftingTable.addShaped("cc_cobblebrick_compat",
 		cc_cobblebrick * 4,  
 		[[quark_cobblebrick, quark_cobblebrick],
 		 [quark_cobblebrick, quark_cobblebrick]]);
+craftingTable.removeRecipe(quark_dirtbrick);
+craftingTable.addShaped("quark_dirtbrick_compat", 
+		quark_dirtbrick * 4,  
+		[[dirt, dirt],
+		 [dirt, dirt]]);
+craftingTable.removeRecipe(cc_dirtbrick);
+craftingTable.addShaped("cc_dirtbrick_compat", 
+		cc_dirtbrick * 4,  
+		[[quark_dirtbrick, quark_dirtbrick],
+		 [quark_dirtbrick, quark_dirtbrick]]);
 craftingTable.removeByName("caverns_and_chasms:cobblestone/mossy_cobblestone_bricks/mossy_cobblestone_bricks");
 craftingTable.addShaped("cc_mossycobblebrick_compat", 
 		cc_mossycobblebrick * 4,  

--- a/scripts/recipes.zs
+++ b/scripts/recipes.zs
@@ -164,3 +164,12 @@ craftingTable.addShaped("candelabra_candles",
 		[[candles, candles, candles],
 		 [gold_ingot, gold_ingot, gold_ingot],
 		 [air, gold_ingot, air]]);
+
+// Rockier Dirt
+// Recipe inspired by Caverns & Chasms's Rocky Dirt
+craftingTable.removeByName("decorative_blocks:dirt_from_rocky_dirt");
+craftingTable.removeByName("decorative_blocks:rocky_dirt");
+craftingTable.addShaped("rockier_dirt",
+		<item:decorative_blocks:rocky_dirt> * 4,
+		[[<item:minecraft:dirt>, <item:minecraft:cobblestone>],
+		 [<item:minecraft:cobblestone>, <item:minecraft:dirt>]]);


### PR DESCRIPTION
Removed caverns_and_chasms:rocky_dirt.
Changed decorative_blocks:rocky_dirt to be like caverns_and_chasms:rocky_dirt.
Prefixed all of Quark's Dirt & Cobblestone Bricks with "Crude".
Changed C&C's Dirt & Cobblestone Bricks to use Quark's as inputs.

Might add a Crafttweaker recipe or datapack fragment to add Quark Bricks to the Stonecutter, but I feel that should be done on Quark's side anyway, like how Cavern & Chasms does?